### PR TITLE
Sidebar message

### DIFF
--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -10,6 +10,11 @@
       font-size: 15px;
       color: #FFFFFF;
       padding-bottom: 5px;
+
+      a{
+        text-decoration: none;
+        color: white;
+      }
     }
 
     &__message{

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -78,7 +78,7 @@ $top-button: #38AEF0;
                   float: left;
 
                     h3{
-                      font-size: 20px;
+                      font-size: 18px;
                       color: #333333;
                       padding-top: 35px;
                       padding-bottom: 15px;
@@ -87,6 +87,12 @@ $top-button: #38AEF0;
                     p{
                       font-size: 12px;
                       color: #999999;
+                      float: left;
+                      padding-right: 5px;
+                    }
+
+                    p:first-of-type{
+                      padding-left: 10px;
                     }
                 }
 

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -90,10 +90,6 @@ $top-button: #38AEF0;
                       float: left;
                       padding-right: 5px;
                     }
-
-                    p:first-of-type{
-                      padding-left: 10px;
-                    }
                 }
 
                 &__right{

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,6 @@ class MessagesController < ApplicationController
     rescue
       redirect_to root_path
     else
-      # binding.pry
       @messages = @group.messages.includes(:user)
       @member = @group.users
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
     rescue
       redirect_to root_path
     else
+      # binding.pry
       @messages = @group.messages.includes(:user)
+      @member = @group.users
     end
   end
 

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -17,7 +17,7 @@
               = group.name
           -if group.messages.pluck(:body).last.present?
             %dt.groups__message= group.messages.pluck(:body).last
-          -elsif group.messages.pluck(:body,:image).last.blank?
+          -elsif group.messages.pluck(:image).last.present?
             %dt.groups__message まだ投稿されていません。
           -else
             %dt.groups__message 画像が投稿されました。

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -15,4 +15,7 @@
           %dl.groups__group-name
             = link_to group_messages_path(group.id) do
               = group.name
-          %dt.groups__message= group.messages.pluck(:body).last
+          -if group.messages.pluck(:body).last == ""
+            %dt.groups__message 画像が投稿されました。
+          -else
+            %dt.groups__message= group.messages.pluck(:body).last

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -10,14 +10,5 @@
             %i.fa.fa-pencil-square-o
           = link_to edit_user_path(current_user.id) do
             %i.fa.fa-cog
-      .groups
-        - @groups.each do |group|
-          %dl.groups__group-name
-            = link_to group_messages_path(group.id) do
-              = group.name
-          -if group.messages.pluck(:body).last.present?
-            %dt.groups__message= group.messages.pluck(:body).last
-          -elsif group.messages.pluck(:image).last.present?
-            %dt.groups__message 画像が投稿されました。
-          -else
-            %dt.groups__message まだ投稿されていません。
+
+      = render partial: "messages/newmessage"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -15,7 +15,9 @@
           %dl.groups__group-name
             = link_to group_messages_path(group.id) do
               = group.name
-          -if group.messages.pluck(:body).last == ""
-            %dt.groups__message 画像が投稿されました。
-          -else
+          -if group.messages.pluck(:body).last.present?
             %dt.groups__message= group.messages.pluck(:body).last
+          -elsif group.messages.pluck(:body,:image).last.blank?
+            %dt.groups__message まだ投稿されていません。
+          -else
+            %dt.groups__message 画像が投稿されました。

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -18,6 +18,6 @@
           -if group.messages.pluck(:body).last.present?
             %dt.groups__message= group.messages.pluck(:body).last
           -elsif group.messages.pluck(:image).last.present?
-            %dt.groups__message まだ投稿されていません。
-          -else
             %dt.groups__message 画像が投稿されました。
+          -else
+            %dt.groups__message まだ投稿されていません。

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -13,5 +13,6 @@
       .groups
         - @groups.each do |group|
           %dl.groups__group-name
-            %i= group.name
-          %dt.groups__message 新着メッセージがありません。
+            = link_to group_messages_path(group.id) do
+              = group.name
+          %dt.groups__message= group.messages.pluck(:body).last

--- a/app/views/messages/_newmessage.html.haml
+++ b/app/views/messages/_newmessage.html.haml
@@ -1,0 +1,12 @@
+.groups
+  - @groups.each do |group|
+    %dl.groups__group-name
+      = link_to group_messages_path(group.id) do
+        = group.name
+    %dt.groups__message
+      -if group.messages.pluck(:body).last.present?
+        = group.messages.pluck(:body).last
+      -elsif group.messages.pluck(:image).last.present?
+        画像が投稿されました。
+      -else
+        まだ投稿されていません。

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -28,9 +28,8 @@
         .header__left
           %h3= @group.name
           %p Member :
-          - groupmembers = @group.users
-          - groupmembers.each do |groupmember|
-            %p= groupmember.name
+          - @member.each do |m|
+            %p= m.name
         .header__right
           = link_to edit_group_path(current_user) do
             Edit

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -24,7 +24,8 @@
     .rightcontent
       .header
         .header__left
-          %h3 Member :
+          %h3= @group.name
+          %p Member :
           - groupmembers = @group.users
           - groupmembers.each do |groupmember|
             %p= groupmember.name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -24,8 +24,10 @@
     .rightcontent
       .header
         .header__left
-          %h3 Sampleグループ
-          %p member1member2member3
+          %h3 Member :
+          - groupmembers = @group.users
+          - groupmembers.each do |groupmember|
+            %p= groupmember.name
         .header__right
           = link_to edit_group_path(current_user) do
             Edit

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,7 +15,7 @@
           %dl.groups__group-name
             = link_to group_messages_path(group.id) do
               = group.name
-          %dt.groups__message 新着メッセージがありません。
+          %dt.groups__message= group.messages.pluck(:body).last
 
   .rightwrapper
     .rightcontent

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,7 +13,8 @@
       .groups
         - @groups.each do |group|
           %dl.groups__group-name
-            = group.name
+            = link_to group_messages_path(group.id) do
+              = group.name
           %dt.groups__message 新着メッセージがありません。
 
   .rightwrapper

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,10 +17,10 @@
               = group.name
           -if group.messages.pluck(:body).last.present?
             %dt.groups__message= group.messages.pluck(:body).last
-          -elsif group.messages.pluck(:body,:image).last.blank?
-            %dt.groups__message まだ投稿されていません。
-          -else
+          -elsif group.messages.pluck(:image).last.present?
             %dt.groups__message 画像が投稿されました。
+          -else
+            %dt.groups__message まだ投稿されていません。
 
   .rightwrapper
     .rightcontent

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,7 +15,10 @@
           %dl.groups__group-name
             = link_to group_messages_path(group.id) do
               = group.name
-          %dt.groups__message= group.messages.pluck(:body).last
+          -if group.messages.pluck(:body).last == ""
+            %dt.groups__message 画像が投稿されました。
+          -else
+            %dt.groups__message= group.messages.pluck(:body).last
 
   .rightwrapper
     .rightcontent

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,10 +15,12 @@
           %dl.groups__group-name
             = link_to group_messages_path(group.id) do
               = group.name
-          -if group.messages.pluck(:body).last == ""
-            %dt.groups__message 画像が投稿されました。
-          -else
+          -if group.messages.pluck(:body).last.present?
             %dt.groups__message= group.messages.pluck(:body).last
+          -elsif group.messages.pluck(:body,:image).last.blank?
+            %dt.groups__message まだ投稿されていません。
+          -else
+            %dt.groups__message 画像が投稿されました。
 
   .rightwrapper
     .rightcontent

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,17 +10,8 @@
             %i.fa.fa-pencil-square-o
           = link_to edit_user_path(current_user.id) do
             %i.fa.fa-cog
-      .groups
-        - @groups.each do |group|
-          %dl.groups__group-name
-            = link_to group_messages_path(group.id) do
-              = group.name
-          -if group.messages.pluck(:body).last.present?
-            %dt.groups__message= group.messages.pluck(:body).last
-          -elsif group.messages.pluck(:image).last.present?
-            %dt.groups__message 画像が投稿されました。
-          -else
-            %dt.groups__message まだ投稿されていません。
+
+      = render partial: "newmessage"
 
   .rightwrapper
     .rightcontent


### PR DESCRIPTION
# What
メッセージをサイドバーに表示し選択できるように実装
グループ名とメンバーを上部に表示

# How
最新メッセージを1件取得する。pluckメソッドを使用(message/index.html.haml)
画像の投稿の有無でメッセージ変更

eachを使ってMemberを上部に表示

# Why
chat-spaceのサイドバーの機能完成のため
上部に選択されているグループを表示し、そのグループに所属するメンバーを表示するため




